### PR TITLE
[#182125818] Entferne Tomcat Abhängigkeit aus meta

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,5 +13,4 @@ galaxy_info:
         - focal
   galaxy_tags:
     - tomcat
-dependencies:
-  - rheinwerk.tomcat_server
+dependencies: []

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -5,4 +5,5 @@
   become_user: root
 
   roles:
+    - rheinwerk.tomcat_server # installs tomcat
     - ansible-role-update_tomcat_config


### PR DESCRIPTION
- führt aktuell dazu, dass die Rheinwerk Tomcat Rolle mit in den ASP Packages landet
- Rolle wird explizit aufgerufen im CI Test