### PR TITLE
[CDINFRA-173] Find and use dynamic Java path

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,7 +8,6 @@ _tomcat:
     - "-Djava.net.preferIPv4Stack=true"
   memory:
     xmx: "{{ (0.65 * ansible_memtotal_mb) | int | abs }}m"
-  java_home: "/usr/lib/jvm/java-11-amazon-corretto"
   java_opts: ""
   ports:
     ajp: 8009

--- a/molecule/default/converge_override.yml
+++ b/molecule/default/converge_override.yml
@@ -23,3 +23,4 @@
   ansible.builtin.set_fact:
     DEFAULT_JAVA_HOME: "{{ corretto_dirs.files[0].path }}"
   when: corretto_dirs.matched > 0
+  failed_when: corretto_dirs.matched == 0

--- a/molecule/default/converge_override.yml
+++ b/molecule/default/converge_override.yml
@@ -5,6 +5,11 @@
     name: tomcat_server
   when: "'molecule-idempotence-notest' not in ansible_skip_tags"
 
+- name: Include AWS JDK role
+  ansible.builtin.include_role:
+    name: aws_jdk
+  when: "'molecule-idempotence-notest' not in ansible_skip_tags"
+
 - name: Find Corretto Java SDK directory
   ansible.builtin.find:
     paths: /usr/lib/jvm
@@ -14,7 +19,7 @@
     depth: 1
   register: corretto_dirs
 
-- name: Set JAVA_HOME to Corretto directory
+- name: Set DEFAULT_JAVA_HOME to Corretto directory
   ansible.builtin.set_fact:
     DEFAULT_JAVA_HOME: "{{ corretto_dirs.files[0].path }}"
   when: corretto_dirs.matched > 0

--- a/molecule/default/converge_override.yml
+++ b/molecule/default/converge_override.yml
@@ -4,3 +4,17 @@
   ansible.builtin.include_role:
     name: tomcat_server
   when: "'molecule-idempotence-notest' not in ansible_skip_tags"
+
+- name: Find Corretto Java SDK directory
+  ansible.builtin.find:
+    paths: /usr/lib/jvm
+    file_type: directory
+    patterns:
+      - '*corretto*'
+    depth: 1
+  register: corretto_dirs
+
+- name: Set JAVA_HOME to Corretto directory
+  ansible.builtin.set_fact:
+    DEFAULT_JAVA_HOME: "{{ corretto_dirs.files[0].path }}"
+  when: corretto_dirs.matched > 0

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,3 +1,7 @@
 - src: https://github.com/Rheinwerk/ansible-role-tomcat_server.git
   name: tomcat_server
   scm: git
+
+- src: https://github.com/Rheinwerk/ansible-role-aws_jdk.git
+  name: aws_jdk
+  scm: git

--- a/templates/etc/systemd/system/tomcat.service.d/10-environment.conf.j2
+++ b/templates/etc/systemd/system/tomcat.service.d/10-environment.conf.j2
@@ -3,7 +3,7 @@ Environment='TZ=Europe/Berlin'
 
 Environment='TMPDIR={{ _tomcat.tmp_dir }}'
 
-Environment='JAVA_HOME={{ _tomcat.java_home }}'
+Environment='JAVA_HOME={{ DEFAULT_JAVA_HOME }}'
 Environment='JAVA_OPTS={% for opt in _tomcat.default_java_opts %}{{ opt }} {% endfor %} {% for opt in _tomcat.java_opts %}{{ opt }} {% endfor %} -Xmx{{ _tomcat.memory.xmx }} -Xms{{ _tomcat.memory.xms|default(_tomcat.memory.xmx) }}'
 
 Environment='CATALINA_HOME={{ _tomcat.install_dir }}'


### PR DESCRIPTION
- JDK wurde vorher nicht installiert in der CI Pipeline, der Pfad `/usr/lib/jvm/java-11-amazon-corretto` existierte nicht was aber nicht validiert wurde